### PR TITLE
Add +1 on strlen to account for null-terminator

### DIFF
--- a/core/pageProcesser/user_api.c
+++ b/core/pageProcesser/user_api.c
@@ -55,7 +55,7 @@ void addUrl(cspider_t *cspider, char *url) {
   if (!bloom_check(cspider->bloom, url)) {
     //no exits
     bloom_add(cspider->bloom, url);
-    unsigned int len = strlen(url);
+    unsigned int len = strlen(url) + 1;
     char *reUrl = (char*)malloc(sizeof(char) * len);
     strncpy(reUrl, url, len);
     uv_rwlock_wrlock(cspider->lock);


### PR DESCRIPTION
In the `addUrl` function of `core/pageProcessor/user_api.c` the url being copied wasn't accounting for the space to null terminate the destination string.
